### PR TITLE
Updating the lamp image path

### DIFF
--- a/apps/web-vm-example.py
+++ b/apps/web-vm-example.py
@@ -53,7 +53,7 @@ def GenerateConfig(context):
                         'boot': True,
                         'autoDelete': True,
                         'initializeParams': {
-                            'sourceImage': 'https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/images/lamp-v20190909'
+                            'sourceImage': 'https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/images/lamp-v20220501'
                         }
                     }],
                     'metadata': {


### PR DESCRIPTION
Updating the lamp image path to resolve the "Image not found error"

## Description

Just updating the lamp stack image on the web-vm because the current one looks to have been replaced with a newer version and name.

## How Has This Been Tested?

I have tested it by running the same GCP Autoscale qwiklab.
